### PR TITLE
Update AdaptagramsLibrary.java

### DIFF
--- a/src/main/java/org/vanted/plugins/layout/adaptagrams/AdaptagramsLibrary.java
+++ b/src/main/java/org/vanted/plugins/layout/adaptagrams/AdaptagramsLibrary.java
@@ -1,6 +1,7 @@
 /**
  * This class provides methods to load the native Adaptagrams libraries.
- * Copyright (c) 2014-2015 Monash University, Australia
+ * Copyright (c) 2014-2025 Monash University, Australia
+ *               2025      University of Applied Sciences Mittweida, Germany
  */
 package org.vanted.plugins.layout.adaptagrams;
 
@@ -10,26 +11,42 @@ import java.io.File;
  * @author Tobias Czauderna
  */
 public class AdaptagramsLibrary {
+
+	/**
+	 * Version of the Adaptagrams library in Vanted
+	 */
+	public static final String VERSION = "1.1";
+	
+	/**
+	 * Return the version of the Adaptagrams library in Vanted.
+	 *
+	 * @return version of the Adaptagrams library in Vanted
+	 */
+	public static String getVersion() {
+		
+		return VERSION;
+		
+	}
 	
 	/**
 	 * Return the names of the native Adaptagrams libraries for the different
-	 * operating systems. There is a 32 bit and 64 bit version of the library for
-	 * Windows and Linux. There is only one library necessary for MacOS.
+	 * operating systems. There is one library for Windows and one library 
+	 * for Linux. There are two libraries for for MacOS (x64 and arm64).
 	 * 
 	 * @return library names for the different operating systems
 	 */
 	public static String[] getLibraryNames() {
 		
-		// the layout library is available on Windows, Linux, and Mac OS
+		// the layout library is available on Windows, Linux, and Mac OS (x64 and arm64)
 		String[] availableOSs = new String[] { "windows", "linux", "mac" };
 		String osName = System.getProperty("os.name");
 		String[] libraryNames = null;
 		if (osName.toLowerCase().contains(availableOSs[0]))
-			libraryNames = new String[] { "adaptagrams32.dll", "adaptagrams64.dll" };
-		if (osName.toLowerCase().contains(availableOSs[1]))
-			libraryNames = new String[] { "adaptagrams32.so", "adaptagrams64.so" };
-		if (osName.toLowerCase().contains(availableOSs[2]))
-			libraryNames = new String[] { "adaptagrams.dylib" };
+			libraryNames = new String[] { "adaptagrams.dll" };
+		else if (osName.toLowerCase().contains(availableOSs[1]))
+			libraryNames = new String[] { "adaptagrams.so" };
+		else if (osName.toLowerCase().contains(availableOSs[2]))
+			libraryNames = new String[] { "adaptagramsx64.dylib", "adaptagramsaarch64.dylib" };
 		return libraryNames;
 		
 	}
@@ -60,75 +77,74 @@ public class AdaptagramsLibrary {
 	 */
 	public static String loadLibrary(String libraryName, String libraryPath) {
 		
+		// the layout library is available on x64 (Windows, Linux, MacOS) and arm64 architectures (MacOS)
+		String[] availableArchitectures = new String[] { "amd64", "x64", "x86_64", "aarch64" };
+		String osArch = System.getProperty("os.arch");
 		// the layout library is available on Windows, Linux, and Mac OS
 		String[] availableOSs = new String[] { "windows", "linux", "mac" };
-		// 32 bit and 64 bit OSs are possible
-		String windowsExt32 = "32.dll";
-		String windowsExt64 = "64.dll";
-		String linuxExt32 = "32.so";
-		String linuxExt64 = "64.so";
-		String macExt = ".dylib";
-		String oldMacExt ="x86.dylib";
-		String osName = System.getProperty("os.name");
-		String ext32 = "";
-		String ext64 = "";
+		String windowsExt = ".dll";
+		String linuxExt = ".so";
+		// two libraries are available for MacOS (x64 and arm64)
+		String macExtx64 = "x64.dylib";
+		String macExtaarch64 = "aarch64.dylib";
 		String ext = "";
-		String osArch = System.getProperty("os.arch");
+		String extx64 = "";
+		String extaarch64 = "";
+		String osName = System.getProperty("os.name");
 		
-		if (!osName.toLowerCase().contains(availableOSs[0]) && !osName.toLowerCase().contains(availableOSs[1])
-				&& !osName.toLowerCase().contains(availableOSs[2]))
+		// for debugging
+		// System.out.println("Current architecture: \"" + osArch + "\"");
+		// System.out.println("Current OS: \"" + osName + "\"");
+		
+		// check whether the library is available for OS
+		if (!osName.toLowerCase().contains(availableOSs[0]) && !osName.toLowerCase().contains(availableOSs[1]) && !osName.toLowerCase().contains(availableOSs[2]))
 			return "Layout library not available for " + osName + "!";
 		
-		// on Windows and on Linux two versions of the native library exist (one for 32
-		// bit and one for 64 bit)
-		if (osName.toLowerCase().contains(availableOSs[0])) {
-			ext32 = windowsExt32;
-			ext64 = windowsExt64;
-		}
-		if (osName.toLowerCase().contains(availableOSs[1])) {
-			ext32 = linuxExt32;
-			ext64 = linuxExt64;
-		}
-		// on Mac OS only one fat native library exists for each architecture type
-		if (osName.toLowerCase().contains(availableOSs[2])){
-			ext = macExt;
+		// check whether the library is available for architecture
+		if (!osArch.toLowerCase().contains(availableArchitectures[0]) && !osArch.toLowerCase().contains(availableArchitectures[1]) && !osArch.toLowerCase().contains(availableArchitectures[2]))
+			return "Layout library not available for " + osName + "!";
+		
+		if (osName.toLowerCase().contains(availableOSs[0]))
+			ext = windowsExt;
+		else if (osName.toLowerCase().contains(availableOSs[1]))
+			ext = linuxExt;
+		else if (osName.toLowerCase().contains(availableOSs[2])) {
+			extx64 = macExtx64;
+			extaarch64 = macExtaarch64;
 		}
 		
 		// check whether the library can be found
-		if (!ext32.isEmpty() && !ext64.isEmpty() && !(new File(libraryPath + libraryName + ext32)).exists()
-				&& !(new File(libraryPath + libraryName + ext64)).exists())
-			return "Could not find " + libraryName + ext32 + " or " + libraryName + ext64 + " in<br>" + libraryPath
-					+ "!";
-		else if (!ext.isEmpty() && !(new File(libraryPath + libraryName + ext)).exists())
-			return "Could not find " + libraryName + ext + " in<br>" + libraryPath + "!";
+		if (!ext.isEmpty() && !(new File(libraryPath + libraryName + ext)).exists())
+			return "Could not find " + libraryName + ext + " in<br>" + libraryPath;
+		else if (!extx64.isEmpty() && !extaarch64.isEmpty() && !(new File(libraryPath + libraryName + extx64)).exists() && !(new File(libraryPath + libraryName + extaarch64)).exists())
+			return "Could not find " + libraryName + extx64 + " or " + libraryName + extaarch64 + " in<br>" + libraryPath;
 		
-		// on Windows and on Linux it is a bit hard to figure out if the Java runtime is
-		// 32 bit or 64 bit
-		// therefore try to load both versions of the library if necessary
 		String errorMessage = "";
-		boolean try64bit;
-		if (!ext32.isEmpty() && !ext64.isEmpty()) {
-			try64bit = true;
-			if ((new File(libraryPath + libraryName + ext32)).exists())
-				try {
-					System.load(libraryPath + libraryName + ext32);
-					try64bit = false;
-				} catch (UnsatisfiedLinkError unsatisfiedLinkError) {
-					errorMessage = unsatisfiedLinkError.getMessage();
-				}
-			if (try64bit && (new File(libraryPath + libraryName + ext64)).exists())
-				try {
-					System.load(libraryPath + libraryName + ext64);
-					errorMessage = "";
-				} catch (UnsatisfiedLinkError unsatisfiedLinkError) {
-					errorMessage = errorMessage + "<br>" + unsatisfiedLinkError.getMessage();
-				}
-		} else if (!ext.isEmpty())
+		// try to load library
+		if (!ext.isEmpty())
 			try {
 				System.load(libraryPath + libraryName + ext);
 			} catch (UnsatisfiedLinkError unsatisfiedLinkError) {
 				errorMessage = unsatisfiedLinkError.getMessage();
 			}
+		// try to load both versions of the library on MacOS if necessary
+		else if (!extx64.isEmpty() && !extaarch64.isEmpty()) {
+			boolean tryaarch64 = true;
+			if ((new File(libraryPath + libraryName + extx64)).exists())
+				try {
+					System.load(libraryPath + libraryName + extx64);
+					tryaarch64 = false;
+				} catch (UnsatisfiedLinkError unsatisfiedLinkError) {
+					errorMessage = unsatisfiedLinkError.getMessage();
+				}
+			if (tryaarch64 && (new File(libraryPath + libraryName + extaarch64)).exists())
+				try {
+					System.load(libraryPath + libraryName + extaarch64);
+					errorMessage = "";
+				} catch (UnsatisfiedLinkError unsatisfiedLinkError) {
+					errorMessage = errorMessage + "<br>" + unsatisfiedLinkError.getMessage();
+				}
+		}
 		
 		return errorMessage;
 		


### PR DESCRIPTION
Only an x64 version of Adaptagrams can be loaded on Windows and Linux. Two versions are available for MacOS (x64, aarch64), the x64 version will be loaded first, if this fails the aarch64 version will be loaded.